### PR TITLE
Fixes #38: カテゴリーテーブルのシーダーファイルの修正

### DIFF
--- a/ecommerce-app/database/seeders/CategorySeeder.php
+++ b/ecommerce-app/database/seeders/CategorySeeder.php
@@ -2,8 +2,8 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use App\Models\Category;
 
 class CategorySeeder extends Seeder
 {
@@ -12,6 +12,23 @@ class CategorySeeder extends Seeder
      */
     public function run(): void
     {
-        //
+        $categories = [
+            'Web 開発',
+            'モバイル開発',
+            'データサイエンス',
+            '機械学習 / AI',
+            'プログラミング言語',
+            'ソフトウェア工学',
+            'DevOps & インフラ',
+            'セキュリティ',
+            'その他'
+        ];
+
+        foreach ($categories as $name) {
+            Category::updateOrCreate(
+                ['name' => $name],  // 検索条件
+                ['name' => $name]   // 挿入または更新する値
+            );
+        }
     }
 }

--- a/ecommerce-app/resources/views/front/home.blade.php
+++ b/ecommerce-app/resources/views/front/home.blade.php
@@ -17,7 +17,7 @@
                         {{ $product->description }}
                     </p>
                     <p class="text-gray-600 text-sm line-clamp-2">
-                    カテゴリー{{ $product->category_id }}
+                        {{ $product->category ? $product->category->name : '' }}
                     </p>
                     <p class="text-gray-600 text-sm line-clamp-2">
                         {{ $product->price }}円
@@ -60,7 +60,7 @@
                         {{ $product->description }}
                     </p>
                     <p class="text-gray-600 text-sm line-clamp-2">
-                    カテゴリー{{ $product->category_id }}
+                        {{ $product->category ? $product->category->name : '' }}
                     </p>
                     <p class="text-gray-600 text-sm line-clamp-2">
                         {{ $product->price }}円

--- a/ecommerce-app/resources/views/front/product.blade.php
+++ b/ecommerce-app/resources/views/front/product.blade.php
@@ -31,7 +31,7 @@
 
                 <!-- カテゴリ & 価格 -->
                 <div class="text-sm text-gray-600 mb-2">
-                    カテゴリ: {{ $product->category_id }} / {{ $product->price }}円
+                    {{ $product->category ? $product->category->name : '' }} {{ $product->price }}円
                 </div>
 
                 <!-- 発売日など -->


### PR DESCRIPTION
## 🔥 変更の概要
このPRでは、[Issue #38](https://github.com/recoursion-backendAdvanced-team6/E-Commerce-backend/issues/38) に関連し、以下の2点の修正を行いました。

## ✨ 変更内容
### ✅ 修正・追加した点
- **シーダーファイルの追加**  
  追加し忘れていたカテゴリーデータ用のシーダーファイルを追加しました。これにより、カテゴリーデータの初期化が正しく行われるようになります。
- **サイトトップと商品一覧の修正**  
  サイトトップおよび商品一覧に表示している商品の場所部分に、カテゴリ名を表示するように修正しました。これにより、ユーザーが商品の所属カテゴリを一目で確認できるようになります。

### ❌ 変更しなかった点
- その他のレイアウトや機能については、今回の修正範囲外としています。

## 🛠 動作確認方法
1. まず、以下のコマンドでシーダーファイルを実行し、カテゴリーデータが正しく登録されることを確認してください
   ```bash
   php artisan db:seed --class=CategorySeeder

2. ブラウザでサイトトップ（例：/）と商品一覧ページ（例：/products）にアクセスし、商品の場所にカテゴリ名が正しく表示されているか確認してください:
